### PR TITLE
CI: add deps for Python2 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
       - name: Install
         run: |
-          sudo apt-get install libeigen3-dev libcppunit-dev python-sip-dev
+          sudo apt-get install libeigen3-dev libcppunit-dev python-sip-dev python-psutils python-futures
       - name: Build orocos_kdl
         run: |
           cd orocos_kdl


### PR DESCRIPTION

# Description

The patch adds two dependencies needed to successfully run the Python2 tests for python_orocos_kdl.

## Test

Test this please.