### PR TITLE
CI: fix dependencies for python2 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install
         run: |
           sudo apt-get install libeigen3-dev libcppunit-dev python-sip-dev
+          sudo apt-get install python-psutil python-future
       - name: Build orocos_kdl
         run: |
           cd orocos_kdl

--- a/python_orocos_kdl/tests/PyKDLtest.py
+++ b/python_orocos_kdl/tests/PyKDLtest.py
@@ -26,6 +26,7 @@ import dynamicstest
 import kinfamtest
 import framestest
 import frameveltest
+import sys
 
 suite = unittest.TestSuite()
 suite.addTest(dynamicstest.suite())


### PR DESCRIPTION

# Description

The tests for `python2` require modules from `psutil` and `future` packages. This patch fixes those dependencies for CI.
Additionally, the main test file imports `sys` package which is also needed.

## Test

Pleas, test this.