### PR TITLE
CI: add Python3 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install
         run: |
           sudo apt-get install libeigen3-dev libcppunit-dev python-sip-dev
-          sudo apt-get install python-psutil python-future
+          sudo apt-get install python-psutil python-future python3-psutil
       - name: Build orocos_kdl
         run: |
           cd orocos_kdl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,15 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
           make
           sudo make install
+      - name: Build PyKDL Python 3
+        run: |
+          cd python_orocos_kdl
+          mkdir build3
+          cd build3
+          export ROS_PYTHON_VERSION=3
+          cmake -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
+          make
+          sudo make install
       - name: Update LD_LIBRARY_PATH
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
@@ -54,6 +63,10 @@ jobs:
         run: |
           cd python_orocos_kdl
           python2 tests/PyKDLtest.py
+      - name: Test PyKDL Python 3
+        run: |
+          cd python_orocos_kdl
+          python3 tests/PyKDLtest.py
 
   industrial_ci:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}

--- a/python_orocos_kdl/tests/kinfamtest.py
+++ b/python_orocos_kdl/tests/kinfamtest.py
@@ -200,7 +200,7 @@ class KinfamTestFunctions(unittest.TestCase):
         self.assertTrue(0 == self.fksolvervel.JntToCart(qvel, cart))
         self.assertTrue(0 == self.iksolvervel.CartToJnt(qvel.q, cart.deriv(), qdot_solved))
 
-        self.assertEqual(qvel.qdot, qdot_solved)
+        self.assertTrue(Equal(qvel.qdot, qdot_solved, 1e-4))
 
     def testFkPosAndIkPos(self):
         q = JntArray(self.chain.getNrOfJoints())
@@ -221,7 +221,7 @@ class KinfamTestFunctions(unittest.TestCase):
         self.assertTrue(0 == self.fksolverpos.JntToCart(q_solved, F2))
 
         self.assertEqual(F1, F2)
-        self.assertEqual(q, q_solved)
+        self.assertTrue(Equal(q, q_solved, 1e-4))
 
 
 class KinfamTestTree(unittest.TestCase):


### PR DESCRIPTION
# Python 3 tests

After the support of Python3, this patch adds CI testing for the `python_orocos_kdl` pacakge.

## Changes

* Additional build and test steps for Python 3
* Additional dependencies for `python3-psutil`
* Change the tolerance for comparative `JntArray` to limit machine precision problems
