### PR TITLE
abi_compatibility: add a symbol to restore alignment

### DIFF
--- a/orocos_kdl/src/chainiksolvervel_pinv_givens.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_givens.hpp
@@ -53,7 +53,7 @@ namespace KDL
         bool transpose,toggle;
         unsigned int m,n;
         MatrixXd jac_eigen,U,V,B;
-        VectorXd S,tempi,UY,SUY,qdot_eigen,v_in_eigen;
+        VectorXd S,tempi,tempj,UY,SUY,qdot_eigen,v_in_eigen;
     };
 }
 #endif


### PR DESCRIPTION

# ABI Compatibility patch

This patch adds a symbol that is no longer used with the purpose of restore the alignment of the class `ChainIkSolverVel_pinv_givens`.
